### PR TITLE
Gulp-utilはdeprecatedとなっているため、推奨のVinylに置き換えた

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   "license": "MIT",
   "homepage": "https://github.com/nandai/gulp-absolute-path",
   "dependencies": {
-    "gulp-util": "^3.0.8",
-    "through2": "^2.0.3"
+    "through2": "^3.0.0",
+    "vinyl": "^2.2.0"
   },
   "devDependencies": {
-    "mocha": "^3.5.3"
+    "mocha": "^5.2.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-const gutil =   require('gulp-util');
+const Vinyl = require('vinyl');
 const assert =  require('assert');
 const abspath = require('../');
 
@@ -15,8 +15,8 @@ function testPath(from, to, args, callback) {
 
   stream.on('end', callback);
 
-  stream.write(new gutil.File({
-    history: __dirname + '/../' + args.file,
+  stream.write(new Vinyl({
+    path: __dirname + '../../' + args.file,
     contents: new Buffer(input)
   }));
 
@@ -35,10 +35,10 @@ function testRequirePath(args, callback) {
  * node_modules path
  */
 describe('node_modules path', function() {
-  it('import gulp-util', function(callback) {
+  it('import vinyl', function(callback) {
     const args = {
       file:   'sub1/sub2/dummy.js',
-      inpath: 'gulp-util'
+      inpath: 'vinyl'
     };
     testImportPath(args, callback);
   });


### PR DESCRIPTION
# 概要

Gulp-utilは非推奨となっており、warningがでるため、Vinylに置き換える。
ref: [Gulp-utilレポジトリ](https://github.com/gulpjs/gulp-util)
ref: https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5

# 変更内容

- gulp-utilをvinylに変更
- mocha, through2のアップデート

# 影響範囲

gulp-utilの使用はテストのみで、メイン機能には依存していないため、gulp-absolute-path本来の機能への影響は無し。
テストのパスは確認済み。
